### PR TITLE
Add support for enterprise Google Maps accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ require( 'google-maps-api' )( 'your api key', ['places'], function( maps ) {
 
 ## API
 
-- apikey `String` - Your Google Maps API Key  
-- \[libraries\] `Array` -  Optional array of libraries to load such as [ 'places' ]
-- \[onComplete\] `function` - Optional callback which will return the google.maps object  
+- apikey `String | Object` - Your Google Maps API Key or an object of the form `{ client: 'APIClientName', channel: 'APIClientChannel' }`
+- \[libraries\] `Array` -  Optional array of libraries to load such as `[ 'places' ]`
+- \[onComplete\] `function` - Optional callback which will return the google.maps object
 
 **Returns**: `Promise` - When this promise resolves it will return the google.maps object

--- a/index.js
+++ b/index.js
@@ -87,10 +87,21 @@ module.exports = function( apikey, libraries, onComplete ) {
         } else {
 
           callBacks.push( [ onOk, onErr, onComplete ] );
-          
-          if( callBacks.length == 1 ){
-            var url = 'https://maps.googleapis.com/maps/api/js?callback=$$mapsCB&key=' + key;
-            if (libraries instanceof Array && libraries.length > 0) {
+
+          if (callBacks.length == 1) {
+            var auth = '';
+            if (typeof key == 'string') {
+
+              auth = '&key=' + key;
+            } else if (typeof key == 'object') {
+
+              auth = '&' + Object.keys(key).map(function (k) {
+                return k + '=' + encodeURIComponent(key[k]);
+              }).join('&');
+            }
+
+            var url = 'https://maps.googleapis.com/maps/api/js?callback=$$mapsCB' + auth;
+            if (Array.isArray(libraries) && libraries.length > 0) {
               url+='&libraries='+libraries.join(',');
             }
             script( url );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-maps-api",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Get up and running with the google maps API quickly",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
This PR adds support for enterprise Google Maps which don't use an API key, but instead use a client key and a trusted list of URLs. It also adds the ability (more or less by accident) to specify the version of the Google Maps library you wish to use by providing `{ key: 'apikey', v: '3.20' }` instead of your API key.

Support is implemented in a backwards compatible manner which accepts an object in place of the `apikey` parameter. This object is mapped to a URI query string using a `.map().join()` and `encodeURIComponent` which should be pretty robust and available on most systems.
